### PR TITLE
Fix link of TheKoLab in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ principles.
 
 * [***Material Design***](https://github.com/MichaelStH/MaterialDesignFeatures)
 * [***Testing***](https://github.com/MichaelStH/Testing/tree/develop)
-* [***TheKoLab***](https://github.com/LVMVRQUXL/thekolab/tree/master) (
+* [***TheKoLab***](https://github.com/TheXtremeLabs/TheKoLab) (
   Repository created and maintained by LAMARQUE Loïc ([*@LVMVRQUXL*](https://github.com/LVMVRQUXL)
   on *Github*))
 


### PR DESCRIPTION
The link was pointing to a private repository. It is now pointing to the right one in the `TheXtremeLabs` organization.